### PR TITLE
Significantly optimize performance

### DIFF
--- a/chase/account.py
+++ b/chase/account.py
@@ -156,16 +156,16 @@ class AccountDetails:
         """
         self.all_account_info = all_account.all_account_info
         self.account_id: str = account_id
-        self.nickname: str = None
-        self.mask: str = None
-        self.detail_type: str = None
-        self.account_value: float = None
-        self.account_value_change: float = None
-        self.eda: str = None
-        self.ira: bool = None
-        self.view_balance: bool = None
-        self.prior_year_ira: bool = None
-        self.show_xfer: bool = None
+        self.nickname: str = ""
+        self.mask: str = ""
+        self.detail_type: str = ""
+        self.account_value: float = -1
+        self.account_value_change: float = -1
+        self.eda: str = ""
+        self.ira: bool = False
+        self.view_balance: bool = False
+        self.prior_year_ira: bool = False
+        self.show_xfer: bool = False
         self.get_account_details()
 
     def get_account_details(self):

--- a/chase/order.py
+++ b/chase/order.py
@@ -272,7 +272,6 @@ class Order:
             warning = self.session.page.wait_for_selector(
                 "#afterHoursModal > div.markets-message > div", timeout=5000
             )
-            warning_text = warning.text_content()
             order_messages["AFTER HOURS WARNING"] = warning
             if after_hours:
                 try:

--- a/chase/order.py
+++ b/chase/order.py
@@ -272,7 +272,7 @@ class Order:
             warning = self.session.page.wait_for_selector(
                 "#afterHoursModal > div.markets-message > div", timeout=5000
             )
-            order_messages["AFTER HOURS WARNING"] = warning
+            order_messages["AFTER HOURS WARNING"] = warning.text_content()
             if after_hours:
                 try:
                     self.session.page.click("#confirmAfterHoursOrder", timeout=2000)

--- a/chase/session.py
+++ b/chase/session.py
@@ -1,14 +1,12 @@
 import json
 import os
-import random
 import traceback
-from time import sleep
 
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 from playwright.sync_api import sync_playwright
 from playwright_stealth import StealthConfig, stealth_sync
 
-from .urls import landing_page, login_page
+from .urls import landing_page, login_page, opt_out_verification_page
 
 
 class ChaseSession:
@@ -179,15 +177,12 @@ class ChaseSession:
             password_box = self.page.query_selector("#password-input")
             username_box.type(r"" + username)
             password_box.type(self.password)
-            sleep(random.uniform(1, 3))
-            self.page.click("#signin-button")
+            self.page.click("#signin-button", timeout=1000)
             try:
                 auth_by_app = self.page.get_by_label("We'll send a push notification")
-                auth_by_app.wait_for(timeout=10000)
-                auth_by_app.click()
+                auth_by_app.click(timeout=1000)
                 next_btn = self.page.get_by_role("button", name="Next")
-                next_btn.wait_for(timeout=10000)
-                next_btn.click()
+                next_btn.click(timeout=10000)
                 print(
                     "Chase is asking for 2fa from the phone app. You have 120sec to approve it."
                 )
@@ -197,18 +192,15 @@ class ChaseSession:
                 pass
             try:
                 select_text = self.page.get_by_label("Get a text. We'll text a one-")
-                select_text.wait_for(timeout=10000)
-                select_text.click()
+                select_text.click(timeout=1000)
                 try:
                     radio_button = self.page.get_by_label(f"xxx-xxx-{last_four}")
-                    radio_button.wait_for(timeout=10000)
-                    radio_button.wait_for(state="visible")
+                    radio_button.wait_for(state="visible", timeout=10000)
                     radio_button.check()
                 except PlaywrightTimeoutError:
                     pass
                 next_btn = self.page.get_by_role("button", name="Next")
-                next_btn.wait_for(timeout=10000)
-                next_btn.click()
+                next_btn.click(timeout=10000)
                 return True
             except PlaywrightTimeoutError:
                 pass
@@ -234,19 +226,19 @@ class ChaseSession:
                     self.page.wait_for_selector(
                         "input#input-sec-auth-options-0", timeout=1000
                     )
-                    sleep(random.uniform(0.1, 1.0))
-                    self.page.click("input#input-sec-auth-options-0")
-                    sleep(random.uniform(0.1, 1.0))
-                    self.page.click('button[type="submit"]')
+                    self.page.click("input#input-sec-auth-options-0", timeout=1000)
+                    self.page.click('button[type="submit"]', timeout=1000)
                     self.page.wait_for_url(landing_page(), timeout=60000)
                     return False
                 except PlaywrightTimeoutError:
                     pass
             try:
+                self.page.wait_for_load_state(state="load", timeout=15000)
+                self.page.wait_for_url(opt_out_verification_page(), timeout=1000)
                 self.page.get_by_text(
                     "Skip this step next time,", exact=False
-                ).wait_for(timeout=5000).click()
-                self.page.get_by_text("Save and go to account").click()
+                ).click(timeout=5000)
+                self.page.get_by_role("button", name="Save and go to account").click()
             except PlaywrightTimeoutError:
                 pass
             if self.title is not None:
@@ -273,27 +265,41 @@ class ChaseSession:
         try:
             code = str(code)
             try:
+                self.page.wait_for_load_state(state="networkidle", timeout=15000)
+            except PlaywrightTimeoutError:
+                raise Exception("Timeout loading 2fa page!")
+            try:
                 code_entry = self.page.get_by_label("Enter your code")
-                code_entry.wait_for(timeout=15000)
-                code_entry.type(code, delay=random.randint(50, 500))
+                code_entry.type(code, timeout=3000)
                 self.page.get_by_role("button", name="Next").click()
-                sleep(5)
             except PlaywrightTimeoutError:
                 pass
             try:
                 self.page.wait_for_selector(
-                    "#otpcode_input-input-field", timeout=150000
+                    "#otpcode_input-input-field", timeout=3000
                 )
                 self.page.fill("#otpcode_input-input-field", code)
                 self.page.fill("#password_input-input-field", self.password)
                 self.page.click('button[type="submit"]')
-                self.page.wait_for_selector("#signin-button", timeout=30000)
-                sleep(5)
             except PlaywrightTimeoutError:
+                pass
+            try:
+                self.page.wait_for_load_state(state="load", timeout=15000)
+                self.page.wait_for_url(opt_out_verification_page(), timeout=1000)
+                self.page.get_by_text(
+                    "Skip this step next time,", exact=False
+                ).click(timeout=5000)
+                self.page.get_by_role("button", name="Save and go to account").click()
+            except PlaywrightTimeoutError:
+                pass
+            try:
+                self.page.wait_for_load_state("load", timeout=30000)
+                self.page.wait_for_url(landing_page(), timeout=60000)
                 if self.title is not None:
                     self.save_storage_state()
                 return True
-            raise Exception("Failed to login to Chase")
+            except PlaywrightTimeoutError:
+                raise Exception("Failed to login to Chase")
         except Exception as e:
             self.close_browser()
             traceback.print_exc()

--- a/chase/session.py
+++ b/chase/session.py
@@ -192,7 +192,7 @@ class ChaseSession:
                 pass
             try:
                 select_text = self.page.get_by_label("Get a text. We'll text a one-")
-                select_text.click(timeout=1000)
+                select_text.click(timeout=15000)
                 try:
                     radio_button = self.page.get_by_label(f"xxx-xxx-{last_four}")
                     radio_button.wait_for(state="visible", timeout=10000)
@@ -270,13 +270,13 @@ class ChaseSession:
                 raise Exception("Timeout loading 2fa page!")
             try:
                 code_entry = self.page.get_by_label("Enter your code")
-                code_entry.type(code, timeout=3000)
+                code_entry.type(code, timeout=15000)
                 self.page.get_by_role("button", name="Next").click()
             except PlaywrightTimeoutError:
                 pass
             try:
                 self.page.wait_for_selector(
-                    "#otpcode_input-input-field", timeout=3000
+                    "#otpcode_input-input-field", timeout=15000
                 )
                 self.page.fill("#otpcode_input-input-field", code)
                 self.page.fill("#password_input-input-field", self.password)

--- a/chase/symbols.py
+++ b/chase/symbols.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+from typing import Optional
 
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
@@ -57,7 +58,7 @@ class SymbolQuote:
         self.last_trade_price: float = 0
         self.last_trade_quantity: float = 0
         self.last_exchange_code: str = ""
-        self.as_of_time: datetime = None
+        self.as_of_time: Optional[datetime] = None
         self.security_description: str = ""
         self.get_symbol_quote()
 
@@ -151,12 +152,12 @@ class SymbolHoldings:
         """
         self.account_id = account_id
         self.session = session
-        self.as_of_time: datetime = None
-        self.asset_allocation_tool_eligible_indicator: bool = None
+        self.as_of_time: Optional[datetime] = None
+        self.asset_allocation_tool_eligible_indicator: bool = False
         self.cash_sweep_position_summary: dict = {}
-        self.custom_position_allowed_indicator: bool = None
+        self.custom_position_allowed_indicator: bool = False
         self.error_responses: list = []
-        self.performance_allowed_indicator: bool = None
+        self.performance_allowed_indicator: bool = False
         self.positions: list = []
         self.positions_summary: dict = {}
         self.raw_json: dict = {}

--- a/chase/urls.py
+++ b/chase/urls.py
@@ -13,6 +13,10 @@ def landing_page():
     return "https://secure.chase.com/web/auth/dashboard#/dashboard/overview"
 
 
+def opt_out_verification_page():
+    return "https://secure05c.chase.com/web/auth/#/logon/recognizeUser/esasiOptout"
+
+
 def account_info():
     return [
         "https://secure.chase.com/svc/rl/accounts/secure/v1/dashboard/data/list",


### PR DESCRIPTION
Hello 👋,

This PR transitions Chase API from explicitly using set timeouts to using timeouts in side of action functions (e.g. `select_text.click(timeout=1000)`). The reason this works is due to Playwright verifying all the necessary checks, such as visible, clickable, etc., before calling an function like `click()`, so as soon as Playwright verifies it for us, we can move along instead of waiting.

Furthermore, this PR fixes a bug where after a user types in SMS 2FA, they might be asked to stop receiving requests to verify for this device. Chase API was not checking in this scenario and would crash. This PR fixes this issue.

Lastly, I cleaned up a few pieces of code that were not following traditional rules of initiation in Python. If you have any questions, please feel free to ask me.

Thank you!